### PR TITLE
Don't init serialization before first frame is run

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -214,6 +214,7 @@ void CGameClient::InitializeProperties(void)
   m_frameRate = 0.0;
   m_frameRateCorrection = 1.0;
   m_sampleRate = 0.0;
+  m_bSerializationInited = false;
   m_serializeSize = 0;
   m_bRewindEnabled = false;
 }
@@ -476,8 +477,6 @@ bool CGameClient::OpenFile(const CFileItem& file, IPlayer* player)
     m_player     = player;
     m_bIsPlaying = true;
 
-    InitSerialization();
-
     return true;
   }
 
@@ -557,6 +556,8 @@ bool CGameClient::InitSerialization()
     }
   }
 
+  m_bSerializationInited = true;
+
   return true;
 }
 
@@ -613,7 +614,10 @@ void CGameClient::RunFrame()
   // Append a new state delta to the rewind buffer
   if (m_bRewindEnabled)
   {
-	GAME_ERROR error = GAME_ERROR_FAILED;
+    if (!m_bSerializationInited)
+      InitSerialization();
+
+    GAME_ERROR error = GAME_ERROR_FAILED;
     try { LogError(error = m_pStruct->Serialize(m_serialState.GetNextState(), m_serialState.GetFrameSize()), "Serialize()"); }
     catch (...) { LogException("Serialize()"); }
 

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -206,6 +206,7 @@ private:
   unsigned int          m_baseWidth;
 
   // Save/rewind functionality
+  bool                  m_bSerializationInited;
   unsigned int          m_serializeSize;
   bool                  m_bRewindEnabled;
   CSerialState          m_serialState;


### PR DESCRIPTION
This fixes a crash when running Mupen64Plus
