### PR TITLE
GL fixes

### DIFF
--- a/addons/kodi.game/addon.xml
+++ b/addons/kodi.game/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.game" version="1.0.20" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.20"/>
+<addon id="kodi.game" version="1.0.25" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.25"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/lib/addons/library.kodi.game/libKODI_game.cpp
+++ b/lib/addons/library.kodi.game/libKODI_game.cpp
@@ -110,11 +110,11 @@ DLLEXPORT void GAME_close_stream(AddonCB* frontend, CB_GameLib* cb, GAME_STREAM_
   return cb->CloseStream(frontend->addonData, stream);
 }
 
-DLLEXPORT void GAME_hw_set_info(AddonCB* frontend, CB_GameLib* cb, game_hw_info* hw_info)
+DLLEXPORT void GAME_enable_hardware_rendering(AddonCB* frontend, CB_GameLib* cb, game_hw_info* hw_info)
 {
   if (frontend == NULL || cb == NULL)
     return;
-  return cb->HwSetInfo(frontend->addonData, hw_info);
+  return cb->EnableHardwareRendering(frontend->addonData, hw_info);
 }
 
 DLLEXPORT uintptr_t GAME_hw_get_current_framebuffer(AddonCB* frontend, CB_GameLib* cb)
@@ -129,6 +129,13 @@ DLLEXPORT game_proc_address_t GAME_hw_get_proc_address(AddonCB* frontend, CB_Gam
   if (frontend == NULL || cb == NULL)
     return NULL;
   return cb->HwGetProcAddress(frontend->addonData, sym);
+}
+
+DLLEXPORT void GAME_render_frame(AddonCB* frontend, CB_GameLib* cb)
+{
+  if (frontend == NULL || cb == NULL)
+    return;
+  cb->RenderFrame(frontend->addonData);
 }
 
 DLLEXPORT bool GAME_open_port(AddonCB* frontend, CB_GameLib* cb, unsigned int port)

--- a/project/cmake/addons/addons/game.libretro/game.libretro.txt
+++ b/project/cmake/addons/addons/game.libretro/game.libretro.txt
@@ -1,1 +1,1 @@
-game.libretro https://github.com/kodi-game/game.libretro master
+game.libretro https://github.com/kodi-game/game.libretro hw-rendering

--- a/xbmc/addons/binary/interfaces/api1/Game/AddonCallbacksGame.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Game/AddonCallbacksGame.cpp
@@ -50,9 +50,10 @@ CAddonCallbacksGame::CAddonCallbacksGame(CAddon* addon) :
   m_callbacks->OpenAudioStream                = OpenAudioStream;
   m_callbacks->AddStreamData                  = AddStreamData;
   m_callbacks->CloseStream                    = CloseStream;
-  m_callbacks->HwSetInfo                      = HwSetInfo;
+  m_callbacks->EnableHardwareRendering        = EnableHardwareRendering;
   m_callbacks->HwGetCurrentFramebuffer        = HwGetCurrentFramebuffer;
   m_callbacks->HwGetProcAddress               = HwGetProcAddress;
+  m_callbacks->RenderFrame                    = RenderFrame;
   m_callbacks->OpenPort                       = OpenPort;
   m_callbacks->ClosePort                      = ClosePort;
   m_callbacks->InputEvent                     = InputEvent;
@@ -139,13 +140,13 @@ void CAddonCallbacksGame::CloseStream(void* addonData, GAME_STREAM_TYPE stream)
   gameClient->CloseStream(stream);
 }
 
-void CAddonCallbacksGame::HwSetInfo(void* addonData, const game_hw_info *hw_info)
+void CAddonCallbacksGame::EnableHardwareRendering(void* addonData, const game_hw_info *hw_info)
 {
   CGameClient* gameClient = GetGameClient(addonData, __FUNCTION__);
   if (!gameClient)
     return;
 
-  gameClient->HwSetInfo(hw_info);
+  gameClient->EnableHardwareRendering(hw_info);
 }
 
 uintptr_t CAddonCallbacksGame::HwGetCurrentFramebuffer(void* addonData)
@@ -164,6 +165,15 @@ game_proc_address_t CAddonCallbacksGame::HwGetProcAddress(void* addonData, const
     return nullptr;
 
   return gameClient->HwGetProcAddress(sym);
+}
+
+void CAddonCallbacksGame::RenderFrame(void* addonData)
+{
+  CGameClient* gameClient = GetGameClient(addonData, __FUNCTION__);
+  if (!gameClient)
+    return;
+
+  gameClient->RenderFrame();
 }
 
 bool CAddonCallbacksGame::OpenPort(void* addonData, unsigned int port)

--- a/xbmc/addons/binary/interfaces/api1/Game/AddonCallbacksGame.h
+++ b/xbmc/addons/binary/interfaces/api1/Game/AddonCallbacksGame.h
@@ -52,9 +52,10 @@ public:
   static int OpenAudioStream(void* addonData, GAME_AUDIO_CODEC codec, const GAME_AUDIO_CHANNEL* channel_map);
   static void AddStreamData(void* addonData, GAME_STREAM_TYPE stream, const uint8_t* data, unsigned int size);
   static void CloseStream(void* addonData, GAME_STREAM_TYPE stream);
-  static void HwSetInfo(void* addonData, const game_hw_info* hw_info);
+  static void EnableHardwareRendering(void* addonData, const game_hw_info* hw_info);
   static uintptr_t HwGetCurrentFramebuffer(void* addonData);
   static game_proc_address_t HwGetProcAddress(void* addonData, const char* sym);
+  static void RenderFrame(void* addonData);
   static bool OpenPort(void* addonData, unsigned int port);
   static void ClosePort(void* addonData, unsigned int port);
   static bool InputEvent(void* addonData, const game_input_event* event);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_callbacks.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_callbacks.h
@@ -94,11 +94,11 @@ typedef struct CB_GameLib
   // -- Hardware rendering callbacks -------------------------------------------
 
   /*!
-   * \brief Set info for hardware rendering
+   * \brief Enable hardware rendering
    *
    * \param hw_info A struct of properties for the hardware rendering system
    */
-  void (*HwSetInfo)(void* addonData, const game_hw_info* hw_info);
+  void (*EnableHardwareRendering)(void* addonData, const game_hw_info* hw_info);
 
   /*!
    * \brief Get the framebuffer for rendering
@@ -115,6 +115,11 @@ typedef struct CB_GameLib
    * \return A function pointer for the specified symbol
    */
   game_proc_address_t (*HwGetProcAddress)(void* addonData, const char* symbol);
+
+  /*!
+   * \brief Called when a frame is being rendered
+   */
+  void (*RenderFrame)(void* addonData);
 
   // --- Input callbacks -------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -21,10 +21,10 @@
 #define KODI_GAME_TYPES_H_
 
 /* current game API version */
-#define GAME_API_VERSION                "1.0.20"
+#define GAME_API_VERSION                "1.0.25"
 
 /* min. game API version */
-#define GAME_MIN_API_VERSION            "1.0.20"
+#define GAME_MIN_API_VERSION            "1.0.25"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_game.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_game.h
@@ -52,9 +52,10 @@ public:
     GAME_open_audio_stream(nullptr),
     GAME_add_stream_data(nullptr),
     GAME_close_stream(nullptr),
-    GAME_hw_set_info(nullptr),
+    GAME_enable_hardware_rendering(nullptr),
     GAME_hw_get_current_framebuffer(nullptr),
     GAME_hw_get_proc_address(nullptr),
+    GAME_render_frame(nullptr),
     GAME_open_port(nullptr),
     GAME_close_port(nullptr),
     GAME_input_event(nullptr),
@@ -119,9 +120,10 @@ public:
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_open_audio_stream)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_add_stream_data)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_close_stream)) throw false;
-      if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_hw_set_info)) throw false;
+      if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_enable_hardware_rendering)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_hw_get_current_framebuffer)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_hw_get_proc_address)) throw false;
+      if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_render_frame)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_open_port)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_close_port)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_input_event)) throw false;
@@ -171,9 +173,9 @@ public:
     GAME_close_stream(m_handle, m_callbacks, stream);
   }
 
-  void HwSetInfo(const struct game_hw_info* hw_info)
+  void EnableHardwareRendering(const struct game_hw_info* hw_info)
   {
-    return GAME_hw_set_info(m_handle, m_callbacks, hw_info);
+    return GAME_enable_hardware_rendering(m_handle, m_callbacks, hw_info);
   }
 
   uintptr_t HwGetCurrentFramebuffer(void)
@@ -184,6 +186,11 @@ public:
   game_proc_address_t HwGetProcAddress(const char* sym)
   {
     return GAME_hw_get_proc_address(m_handle, m_callbacks, sym);
+  }
+
+  void RenderFrame()
+  {
+    return GAME_render_frame(m_handle, m_callbacks);
   }
 
   bool OpenPort(unsigned int port)
@@ -211,9 +218,10 @@ protected:
   int (*GAME_open_audio_stream)(void* handle, CB_GameLib* cb, GAME_AUDIO_CODEC, const GAME_AUDIO_CHANNEL*);
   int (*GAME_add_stream_data)(void* handle, CB_GameLib* cb, GAME_STREAM_TYPE, const uint8_t*, unsigned int);
   int (*GAME_close_stream)(void* handle, CB_GameLib* cb, GAME_STREAM_TYPE);
-  void (*GAME_hw_set_info)(void* handle, CB_GameLib* cb, const struct game_hw_info*);
+  void (*GAME_enable_hardware_rendering)(void* handle, CB_GameLib* cb, const struct game_hw_info*);
   uintptr_t (*GAME_hw_get_current_framebuffer)(void* handle, CB_GameLib* cb);
   game_proc_address_t (*GAME_hw_get_proc_address)(void* handle, CB_GameLib* cb, const char*);
+  void (*GAME_render_frame)(void* handle, CB_GameLib* cb);
   bool (*GAME_open_port)(void* handle, CB_GameLib* cb, unsigned int);
   void (*GAME_close_port)(void* handle, CB_GameLib* cb, unsigned int);
   bool (*GAME_input_event)(void* handle, CB_GameLib* cb, const game_input_event* event);

--- a/xbmc/cores/RetroPlayer/Makefile
+++ b/xbmc/cores/RetroPlayer/Makefile
@@ -1,6 +1,7 @@
 SRCS=PixelConverter.cpp \
      RetroPlayer.cpp \
      RetroPlayerAudio.cpp \
+     RetroPlayerGL.cpp \
      RetroPlayerVideo.cpp
 
 LIB=retroplayer.a

--- a/xbmc/cores/RetroPlayer/RetroGlRenderPicture.h
+++ b/xbmc/cores/RetroPlayer/RetroGlRenderPicture.h
@@ -22,12 +22,18 @@
 
 namespace LIBRETROGL
 {
-    class CRetroGlRenderPicture
+  class CRetroGlRenderPicture
+  {
+  public:
+    CRetroGlRenderPicture() :
+      texWidth(0),
+      texHeight(0)
     {
-    public:
-        CRetroGlRenderPicture(){}
-        int texWidth, texHeight;
-        GLuint texture[1];
-        GLuint depth[1];
-    };
+    }
+
+    unsigned int texWidth;
+    unsigned int texHeight;
+    GLuint texture[1];
+    GLuint depth[1];
+  };
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayerGL.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerGL.cpp
@@ -1,0 +1,255 @@
+/*
+ *      Copyright (C) 2012-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RetroPlayerGL.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderFlags.h" // for RENDER_FMT_LIBRETROGL
+#include "cores/VideoPlayer/VideoRenderers/RenderFormats.h" // for CONF_FLAGS_FULLSCREEN
+#include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "cores/VideoPlayer/DVDClock.h" // for DVD_NOPTS_VALUE
+#include "utils/log.h"
+#include "windowing/WindowingFactory.h"
+
+#include <atomic> // TODO
+
+using namespace GAME;
+
+CRetroPlayerGL::CRetroPlayerGL(CRenderManager& renderManager, CProcessInfo& processInfo) :
+  m_renderManager(renderManager),
+  m_processInfo(processInfo),
+  m_bConfigured(false),
+  m_Display(nullptr),
+  m_Window(0),
+  m_glContext(nullptr),
+  m_glWindow(0),
+  m_pixmap(0),
+  m_glPixmap(0),
+  m_fboId(0),
+  m_textureId(0)
+{
+}
+
+CRetroPlayerGL::~CRetroPlayerGL()
+{
+  Destroy();
+}
+
+bool CRetroPlayerGL::Create()
+{
+  if (!CreateGlxContext())
+    return false;
+
+  if (!CreateTexture())
+    return false;
+
+  if (!CreateFramebuffer())
+  {
+    CLog::Log(LOGINFO, "RetroPlayerGL: Could not create framebuffer object");
+    return false;
+  }
+
+  return true;
+}
+
+void CRetroPlayerGL::Destroy()
+{
+  //! @todo
+}
+
+uintptr_t CRetroPlayerGL::GetCurrentFramebuffer()
+{
+  return static_cast<uintptr_t>(m_fboId);
+}
+
+RetroGLProcAddress CRetroPlayerGL::GetProcAddress(const char* sym)
+{
+  return glXGetProcAddress(reinterpret_cast<const GLubyte*>(sym));
+}
+
+void CRetroPlayerGL::RenderFrame()
+{
+  DVDVideoPicture picture = { };
+  GetPicture(picture);
+
+  if (!Configure(picture))
+  {
+    CLog::Log(LOGERROR, "RetroPlayerGL: Failed to configure renderer");
+  }
+  else
+  {
+    SendPicture(picture);
+  }
+}
+
+bool CRetroPlayerGL::Configure(DVDVideoPicture& picture)
+{
+  if (!m_bConfigured)
+  {
+    const float framerate = 60; //! @todo Get from game client
+
+    // Determine RenderManager flags
+    unsigned int flags = CONF_FLAGS_FULLSCREEN;     // Allow fullscreen
+
+    const int orientation = 180; //! @todo Move to game.libretro. See note at https://github.com/a1rwulf/xbmc/commit/dc1ea03#commitcomment-18250984
+
+    const int buffers = 1; //! @todo
+
+    m_bConfigured = m_renderManager.Configure(picture, framerate, flags, orientation, buffers);
+  }
+
+  return m_bConfigured;
+}
+
+void CRetroPlayerGL::GetPicture(DVDVideoPicture& picture)
+{
+  m_retroglpic.texWidth = 640;
+  m_retroglpic.texHeight = 480;
+
+  picture.libretrogl     = &m_retroglpic;
+  picture.format         = RENDER_FMT_LIBRETROGL;
+  picture.dts            = DVD_NOPTS_VALUE;
+  picture.pts            = DVD_NOPTS_VALUE;
+  picture.iWidth         = m_retroglpic.texWidth;
+  picture.iHeight        = m_retroglpic.texHeight;
+  picture.iDisplayWidth  = m_retroglpic.texWidth;
+  picture.iDisplayHeight = m_retroglpic.texHeight;
+}
+
+void CRetroPlayerGL::SendPicture(DVDVideoPicture& picture)
+{
+  std::atomic_bool bAbortOutput(false); // TODO
+
+  int index = m_renderManager.AddVideoPicture(picture);
+  if (index < 0)
+  {
+    // Video device might not be done yet, drop the frame
+  }
+  else
+  {
+    m_renderManager.FlipPage(bAbortOutput);
+  }
+}
+
+bool CRetroPlayerGL::CreateGlxContext()
+{
+  GLXContext glContext;
+
+  m_Display = g_Windowing.GetDisplay();
+  glContext = g_Windowing.GetGlxContext();
+  m_Window = g_Windowing.GetWindow();
+
+  // Get our window attribs.
+  XWindowAttributes wndattribs;
+  XGetWindowAttributes(m_Display, m_Window, &wndattribs);
+
+  // Get visual Info
+  XVisualInfo visInfo;
+  visInfo.visualid = wndattribs.visual->visualid;
+  int nvisuals = 0;
+  XVisualInfo* visuals = XGetVisualInfo(m_Display, VisualIDMask, &visInfo, &nvisuals);
+  if (nvisuals != 1)
+  {
+    CLog::Log(LOGERROR, "RetroPlayerGL::CreateGlxContext - could not find visual");
+    return false;
+  }
+  visInfo = visuals[0];
+  XFree(visuals);
+
+  m_pixmap = XCreatePixmap(m_Display,
+                           m_Window,
+                           192,
+                           108,
+                           visInfo.depth);
+  if (!m_pixmap)
+  {
+    CLog::Log(LOGERROR, "RetroPlayerGL::CreateGlxContext - Unable to create XPixmap");
+    return false;
+  }
+
+  // create gl pixmap
+  m_glPixmap = glXCreateGLXPixmap(m_Display, &visInfo, m_pixmap);
+
+  if (!m_glPixmap)
+  {
+    CLog::Log(LOGINFO, "RetroPlayerGL::CreateGlxContext - Could not create glPixmap");
+    return false;
+  }
+
+  m_glContext = glXCreateContext(m_Display, &visInfo, glContext, True);
+
+  if (!glXMakeCurrent(m_Display, m_glPixmap, m_glContext))
+  {
+    CLog::Log(LOGINFO, "RetroPlayerGL::CreateGlxContext - Could not make Pixmap current");
+    return false;
+  }
+
+  CLog::Log(LOGNOTICE, "RetroPlayerGL::CreateGlxContext - created context");
+  return true;
+}
+
+bool CRetroPlayerGL::CreateTexture()
+{
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glGenTextures(1, &m_retroglpic.texture[0]);
+
+  glBindTexture(GL_TEXTURE_2D, m_retroglpic.texture[0]);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); // automatic mipmap
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 640, 480, 0,
+               GL_RGB, GL_UNSIGNED_BYTE, 0);
+
+  return true;
+}
+
+bool CRetroPlayerGL::CreateFramebuffer()
+{
+  glGenFramebuffers(1, &m_fboId);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fboId);
+
+  // attach the texture to FBO color attachment point
+  glFramebufferTexture2D(GL_FRAMEBUFFER,            // 1. fbo target: GL_FRAMEBUFFER
+                         GL_COLOR_ATTACHMENT0,      // 2. attachment point
+                         GL_TEXTURE_2D,             // 3. tex target: GL_TEXTURE_2D
+                         m_retroglpic.texture[0],   // 4. tex ID
+                         0);                        // 5. mipmap level: 0(base){
+
+  CreateDepthbuffer();
+
+  // check FBO status
+  GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+  if(status != GL_FRAMEBUFFER_COMPLETE)
+    return false;
+
+  return true;
+}
+
+bool CRetroPlayerGL::CreateDepthbuffer()
+{
+  glGenRenderbuffers(1, &m_retroglpic.depth[0]);
+  glBindRenderbuffer(GL_RENDERBUFFER, m_retroglpic.depth[0]);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, 640, 480);
+  glBindRenderbuffer(GL_RENDERBUFFER, 0);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                            GL_RENDERBUFFER, m_retroglpic.depth[0]);
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/RetroPlayerGL.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerGL.h
@@ -1,0 +1,79 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define GLX_GLXEXT_PROTOTYPES
+#include "system_gl.h"
+
+#include "RetroGlRenderPicture.h"
+#include "games/addons/GameClientCallbacks.h"
+
+#include <GL/glx.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+class CProcessInfo;
+class CRenderManager;
+struct DVDVideoPicture;
+
+namespace GAME
+{
+  class CRetroPlayerGL : public IGameRenderingCallback
+  {
+  public:
+    CRetroPlayerGL(CRenderManager& m_renderManager, CProcessInfo& m_processInfo);
+
+    virtual ~CRetroPlayerGL();
+
+    // implementation of IGameRenderingCallback
+    virtual bool Create() override;
+    virtual void Destroy() override;
+    virtual uintptr_t GetCurrentFramebuffer() override;
+    virtual RetroGLProcAddress GetProcAddress(const char *sym) override;
+    virtual void RenderFrame() override;
+
+  private:
+    bool Configure(DVDVideoPicture& picture);
+    void GetPicture(DVDVideoPicture& picture);
+    void SendPicture(DVDVideoPicture& picture);
+
+    bool CreateGlxContext();
+    bool CreateTexture();
+    bool CreateFramebuffer();
+    bool CreateDepthbuffer();
+
+    // Construction parameters
+    CRenderManager& m_renderManager;
+    CProcessInfo&   m_processInfo;
+
+    // Rendering properties
+    bool m_bConfigured;
+    Display *m_Display;
+    Window m_Window;
+    GLXContext m_glContext;
+    GLXWindow m_glWindow;
+    Pixmap    m_pixmap;
+    GLXPixmap m_glPixmap;
+    GLuint m_fboId;
+    GLuint m_textureId;
+
+    LIBRETROGL::CRetroGlRenderPicture m_retroglpic;
+  };
+}

--- a/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
@@ -1,0 +1,25 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace GAME
+{
+  typedef void (*RetroGLProcAddress)(void);
+}

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -19,12 +19,12 @@
  */
 
 #include "RetroPlayerVideo.h"
+#include "RetroPlayerGL.h"
 #include "PixelConverter.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "utils/log.h"
-#include "windowing/WindowingFactory.h"
 
 #include <atomic> // TODO
 
@@ -91,6 +91,13 @@ bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
 
 void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 {
+  //! @todo Move this ugly check to game.libretro
+  if (data == reinterpret_cast<const uint8_t*>(-1))
+  {
+    HardwareRendering()->RenderFrame();
+    return;
+  }
+
   DVDVideoPicture picture = { };
 
   if (GetPicture(data, size, picture))
@@ -112,6 +119,14 @@ void CRetroPlayerVideo::CloseStream()
   m_pixelConverter.reset();
 }
 
+IGameRenderingCallback* CRetroPlayerVideo::HardwareRendering()
+{
+  if (!m_hardwareRendering)
+    m_hardwareRendering.reset(new CRetroPlayerGL(m_renderManager, m_processInfo));
+
+  return m_hardwareRendering.get();
+}
+
 bool CRetroPlayerVideo::Configure(DVDVideoPicture& picture)
 {
   if (!m_bConfigured)
@@ -119,8 +134,6 @@ bool CRetroPlayerVideo::Configure(DVDVideoPicture& picture)
     // Determine RenderManager flags
     unsigned int flags = CONF_FLAGS_YUVCOEF_BT601 | // color_matrix = 4
                          CONF_FLAGS_FULLSCREEN;     // Allow fullscreen
-
-    const int orientation = picture.format == RENDER_FMT_LIBRETROGL ? 180 : 0; // (90 = 5, 180 = 2, 270 = 7) if we ever want to use RETRO_ENVIRONMENT_SET_ROTATION
 
     const int buffers = 1; // TODO
 
@@ -188,129 +201,4 @@ void CRetroPlayerVideo::SendPicture(DVDVideoPicture& picture)
   {
     m_renderManager.FlipPage(bAbortOutput);
   }
-}
-
-game_proc_address_t CRetroPlayerVideo::GetProcAddress(const char* sym)
-{
-  return glXGetProcAddress((const GLubyte*) sym);
-}
-
-uintptr_t CRetroPlayerVideo::GetCurrentFramebuffer()
-{
-  return (uintptr_t)m_fboId;
-}
-
-bool CRetroPlayerVideo::CreateGlxContext()
-{
-  GLXContext   glContext;
-
-  m_Display = g_Windowing.GetDisplay();
-  glContext = g_Windowing.GetGlxContext();
-  m_Window = g_Windowing.GetWindow();
-
-  // Get our window attribs.
-  XWindowAttributes wndattribs;
-  XGetWindowAttributes(m_Display, m_Window, &wndattribs);
-
-  // Get visual Info
-  XVisualInfo visInfo;
-  visInfo.visualid = wndattribs.visual->visualid;
-  int nvisuals = 0;
-  XVisualInfo* visuals = XGetVisualInfo(m_Display, VisualIDMask, &visInfo, &nvisuals);
-  if (nvisuals != 1)
-  {
-    CLog::Log(LOGERROR, "RetroPlayer::CreateGlxContext - could not find visual");
-    return false;
-  }
-  visInfo = visuals[0];
-  XFree(visuals);
-
-  m_pixmap = XCreatePixmap(m_Display,
-                           m_Window,
-                           192,
-                           108,
-                           visInfo.depth);
-  if (!m_pixmap)
-  {
-    CLog::Log(LOGERROR, "RetroPlayer::CreateGlxContext - Unable to create XPixmap");
-    return false;
-  }
-
-  // create gl pixmap
-  m_glPixmap = glXCreateGLXPixmap(m_Display, &visInfo, m_pixmap);
-
-  if (!m_glPixmap)
-  {
-    CLog::Log(LOGINFO, "RetroPlayer::CreateGlxContext - Could not create glPixmap");
-    return false;
-  }
-
-  m_glContext = glXCreateContext(m_Display, &visInfo, glContext, True);
-
-  if (!glXMakeCurrent(m_Display, m_glPixmap, m_glContext))
-  {
-    CLog::Log(LOGINFO, "RetroPlayer::CreateGlxContext - Could not make Pixmap current");
-    return false;
-  }
-
-  CLog::Log(LOGNOTICE, "RetroPlayer::CreateGlxContext - created context");
-  return true;
-}
-
-bool CRetroPlayerVideo::CreateFramebuffer()
-{
-  glGenFramebuffers(1, &m_fboId);
-  glBindFramebuffer(GL_FRAMEBUFFER, m_fboId);
-
-  // attach the texture to FBO color attachment point
-  glFramebufferTexture2D(GL_FRAMEBUFFER,          // 1. fbo target: GL_FRAMEBUFFER
-                         GL_COLOR_ATTACHMENT0,      // 2. attachment point
-                         GL_TEXTURE_2D,             // 3. tex target: GL_TEXTURE_2D
-                         m_retroglpic.texture[0],   // 4. tex ID
-                         0);                        // 5. mipmap level: 0(base){
-
-  CreateDepthbuffer();
-
-  // check FBO status
-  GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-  if(status != GL_FRAMEBUFFER_COMPLETE)
-    return false;
-
-  return true;
-}
-
-bool CRetroPlayerVideo::CreateTexture()
-{
-  glBindTexture(GL_TEXTURE_2D, 0);
-  glGenTextures(1, &m_retroglpic.texture[0]);
-
-  glBindTexture(GL_TEXTURE_2D, m_retroglpic.texture[0]);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); // automatic mipmap
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 640, 480, 0,
-               GL_RGB, GL_UNSIGNED_BYTE, 0);
-
-  return true;
-}
-
-bool CRetroPlayerVideo::CreateDepthbuffer()
-{
-  glGenRenderbuffers(1, &m_retroglpic.depth[0]);
-  glBindRenderbuffer(GL_RENDERBUFFER, m_retroglpic.depth[0]);
-  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, 640, 480);
-  glBindRenderbuffer(GL_RENDERBUFFER, 0);
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                            GL_RENDERBUFFER, m_retroglpic.depth[0]);
-  return true;
-}
-
-void CRetroPlayerVideo::CreateHwRenderContext()
-{
-  CreateGlxContext();
-  CreateTexture();
-  if (!CreateFramebuffer())
-    CLog::Log(LOGINFO, "RetroPlayerVideo: Could not create framebuffer object");
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -91,13 +91,6 @@ bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
 
 void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 {
-  //! @todo Move this ugly check to game.libretro
-  if (data == reinterpret_cast<const uint8_t*>(-1))
-  {
-    HardwareRendering()->RenderFrame();
-    return;
-  }
-
   DVDVideoPicture picture = { };
 
   if (GetPicture(data, size, picture))

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
@@ -18,13 +18,6 @@
  *
  */
 #pragma once
-#define GLX_GLXEXT_PROTOTYPES
-#include "system_gl.h"
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <GL/glx.h>
-#include "RetroGlRenderPicture.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
 
 #include "games/addons/GameClientCallbacks.h"
 //#include "threads/Thread.h"
@@ -52,10 +45,8 @@ namespace GAME
     virtual bool OpenEncodedStream(AVCodecID codec) override;
     virtual void AddData(const uint8_t* data, unsigned int size) override;
     virtual void CloseStream() override;
+    virtual IGameRenderingCallback* HardwareRendering() override;
 
-    uintptr_t GetCurrentFramebuffer();
-    game_proc_address_t GetProcAddress(const char* sym);
-    void CreateHwRenderContext();
     /*
   protected:
     // implementation of CThread
@@ -67,11 +58,6 @@ namespace GAME
     bool GetPicture(const uint8_t* data, unsigned int size, DVDVideoPicture& picture);
     void SendPicture(DVDVideoPicture& picture);
 
-    bool CreateGlxContext();
-    bool CreateFramebuffer();
-    bool CreateTexture();
-    bool CreateDepthbuffer();
-
     // Construction parameters
     CDVDClock&      m_clock;
     CRenderManager& m_renderManager;
@@ -82,16 +68,5 @@ namespace GAME
     bool         m_bConfigured; // Need first picture to configure the render manager
     unsigned int m_droppedFrames;
     std::unique_ptr<CPixelConverter> m_pixelConverter;
-
-    Display *m_Display;
-    Window m_Window;
-    GLXContext m_glContext;
-    GLXWindow m_glWindow;
-    Pixmap    m_pixmap;
-    GLXPixmap m_glPixmap;
-    GLuint m_fboId;
-    GLuint m_textureId;
-
-    LIBRETROGL::CRetroGlRenderPicture m_retroglpic;
   };
 }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -962,9 +962,9 @@ void CGameClient::LogException(const char* strFunctionName) const
   CLog::Log(LOGERROR, "Please contact the developer of this add-on: %s", Author().c_str());
 }
 
-void CGameClient::HwSetInfo(const game_hw_info *hw_info)
+void CGameClient::EnableHardwareRendering(const game_hw_info *hw_info)
 {
-  CLog::Log(LOGINFO, "GAME - entered HwSetInfo");
+  CLog::Log(LOGINFO, "GAME - entered EnableHardwareRendering");
   return;
 }
 
@@ -987,4 +987,9 @@ void CGameClient::HwContextReset()
 void CGameClient::CreateHwRenderContext()
 {
   m_video->HardwareRendering()->Create();
+}
+
+void CGameClient::RenderFrame()
+{
+  m_video->HardwareRendering()->RenderFrame();
 }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -326,8 +326,6 @@ bool CGameClient::LoadGameInfo(const std::string& logPath)
   CLog::Log(LOGINFO, "GAME: Base Height:  %u", av_info.geometry.base_height);
   CLog::Log(LOGINFO, "GAME: Max Width:    %u", av_info.geometry.max_width);
   CLog::Log(LOGINFO, "GAME: Max Height:   %u", av_info.geometry.max_height);
-  CLog::Log(LOGINFO, "GAME: Base Width:    %u", av_info.geometry.base_width);
-  CLog::Log(LOGINFO, "GAME: Base Height:   %u", av_info.geometry.base_height);
   CLog::Log(LOGINFO, "GAME: Aspect Ratio: %f", av_info.geometry.aspect_ratio);
   CLog::Log(LOGINFO, "GAME: FPS:          %f", av_info.timing.fps);
   CLog::Log(LOGINFO, "GAME: Sample Rate:  %f", av_info.timing.sample_rate);
@@ -972,12 +970,12 @@ void CGameClient::HwSetInfo(const game_hw_info *hw_info)
 
 uintptr_t CGameClient::HwGetCurrentFramebuffer()
 {
-  return m_video->GetCurrentFramebuffer();
+  return m_video->HardwareRendering()->GetCurrentFramebuffer();
 }
 
 game_proc_address_t CGameClient::HwGetProcAddress(const char *sym)
 {
-  return m_video->GetProcAddress(sym);
+  return m_video->HardwareRendering()->GetProcAddress(sym);
 }
 
 void CGameClient::HwContextReset()
@@ -988,5 +986,5 @@ void CGameClient::HwContextReset()
 
 void CGameClient::CreateHwRenderContext()
 {
-  m_video->CreateHwRenderContext();
+  m_video->HardwareRendering()->Create();
 }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -119,6 +119,7 @@ CGameClient::CGameClient(ADDON::AddonProps props,
   m_bSupportsKeyboard(bSupportsKeyboard),
   m_audio(nullptr),
   m_video(nullptr),
+  m_bHardwareRendering(false),
   m_region(GAME_REGION_UNKNOWN)
 {
   std::transform(extensions.begin(), extensions.end(),
@@ -367,6 +368,12 @@ void CGameClient::CreatePlayback()
 {
   if (m_bSupportsGameLoop)
   {
+    if (m_bHardwareRendering)
+    {
+      CreateHwRenderContext();
+      HwContextReset();
+    }
+
     const bool bRewindEnabled = CSettings::GetInstance().GetBool(CSettings::SETTING_GAMES_ENABLEREWIND);
     const size_t serializeSize = SerializeSize();
     if (bRewindEnabled && serializeSize > 0)
@@ -426,6 +433,7 @@ void CGameClient::CloseFile()
 
   m_audio = nullptr;
   m_video = nullptr;
+  m_bHardwareRendering = false;
 }
 
 void CGameClient::RunFrame()
@@ -965,7 +973,7 @@ void CGameClient::LogException(const char* strFunctionName) const
 void CGameClient::EnableHardwareRendering(const game_hw_info *hw_info)
 {
   CLog::Log(LOGINFO, "GAME - entered EnableHardwareRendering");
-  return;
+  m_bHardwareRendering = true;
 }
 
 uintptr_t CGameClient::HwGetCurrentFramebuffer()

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -158,11 +158,12 @@ public:
   virtual void OnKeyRelease(const CKey& key) override;
 
   // OpenGL HW Rendering
-  void HwSetInfo(const game_hw_info *hw_info);
+  void EnableHardwareRendering(const game_hw_info *hw_info);
   uintptr_t HwGetCurrentFramebuffer();
   game_proc_address_t HwGetProcAddress(const char *sym);
   void HwContextReset();
   void CreateHwRenderContext();
+  void RenderFrame();
 
 private:
   // Private gameplay functions

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -161,8 +161,6 @@ public:
   void EnableHardwareRendering(const game_hw_info *hw_info);
   uintptr_t HwGetCurrentFramebuffer();
   game_proc_address_t HwGetProcAddress(const char *sym);
-  void HwContextReset();
-  void CreateHwRenderContext();
   void RenderFrame();
 
 private:
@@ -181,6 +179,10 @@ private:
   void CloseKeyboard(void);
   ControllerVector GetControllers(void) const;
   bool AcceptsInput(void);
+
+  // OpenGL HW Rendering
+  void HwContextReset();
+  void CreateHwRenderContext();
 
   // Helper functions
   void LogAddonProperties(void) const;
@@ -203,6 +205,7 @@ private:
   std::atomic_bool      m_bIsPlaying;          // True between OpenFile() and CloseFile()
   IGameAudioCallback*   m_audio;               // The audio callback passed to OpenFile()
   IGameVideoCallback*   m_video;               // The video callback passed to OpenFile()
+  bool                  m_bHardwareRendering;  // True if hardware rendering has been enabled
   CGameClientTiming     m_timing;              // Class to scale playback to avoid resampling audio
   PERIPHERALS::EventRateHandle m_inputRateHandle; // Handle while keeping the input sampling rate at the frame rate
   std::unique_ptr<IGameClientPlayback> m_playback; // Interface to control playback

--- a/xbmc/games/addons/GameClientCallbacks.h
+++ b/xbmc/games/addons/GameClientCallbacks.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "cores/AudioEngine/Utils/AEChannelData.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 #include "libavcodec/avcodec.h"
 #include "libavutil/pixfmt.h"
@@ -43,6 +43,8 @@ namespace GAME
     virtual void CloseStream() = 0;
   };
 
+  class IGameRenderingCallback;
+
   class IGameVideoCallback
   {
   public:
@@ -52,8 +54,20 @@ namespace GAME
     virtual bool OpenEncodedStream(AVCodecID codec) = 0;
     virtual void AddData(const uint8_t* data, unsigned int size) = 0;
     virtual void CloseStream() = 0;
+
+    // Access hardware rendering interface
+    virtual IGameRenderingCallback* HardwareRendering() = 0;
+  };
+
+  class IGameRenderingCallback
+  {
+  public:
+    virtual ~IGameRenderingCallback() = default;
+
+    virtual bool Create() = 0;
+    virtual void Destroy() = 0;
     virtual uintptr_t GetCurrentFramebuffer() = 0;
-    virtual game_proc_address_t GetProcAddress(const char *sym) = 0;
-    virtual void CreateHwRenderContext() = 0;
+    virtual RetroGLProcAddress GetProcAddress(const char *sym) = 0;
+    virtual void RenderFrame() = 0;
   };
 }

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -164,13 +164,3 @@ void CGameClientReversiblePlayback::UpdatePlaybackStats()
   m_totalTimeMs = MathUtils::round_int(1000.0 * total / m_gameLoop.FPS());
   m_cacheTimeMs = MathUtils::round_int(1000.0 * cached / m_gameLoop.FPS());
 }
-
-void CGameClientReversiblePlayback::HwContextReset()
-{
-  m_gameClient->HwContextReset();
-}
-
-void CGameClientReversiblePlayback::CreateHwRenderContext()
-{
-  m_gameClient->CreateHwRenderContext();
-}

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.h
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.h
@@ -54,8 +54,6 @@ namespace GAME
     // implementation of IGameLoopCallback
     virtual void FrameEvent() override;
     virtual void RewindEvent() override;
-    virtual void HwContextReset() override;
-    virtual void CreateHwRenderContext() override;
 
   private:
     void RewindFrames(unsigned int frames);

--- a/xbmc/games/addons/playback/GameLoop.cpp
+++ b/xbmc/games/addons/playback/GameLoop.cpp
@@ -35,8 +35,7 @@ CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps) :
   m_callback(callback),
   m_fps(fps ? fps : DEFAULT_FPS),
   m_speedFactor(1.0),
-  m_lastFrameMs(0.0),
-  m_firstRun(true)
+  m_lastFrameMs(0.0)
 {
 }
 
@@ -66,7 +65,6 @@ void CGameLoop::Process(void)
   double nextFrameMs = NowMs();
 
   CSingleLock lock(m_mutex);
-  m_callback->CreateHwRenderContext();
 
   while (!m_bStop)
   {
@@ -74,12 +72,6 @@ void CGameLoop::Process(void)
 
     {
       CSingleExit exit(m_mutex);
-      if (m_firstRun)
-      {
-        m_callback->HwContextReset();
-        m_firstRun = false;
-      }
-
       if (speedFactor > 0.0)
         m_callback->FrameEvent();
       else if (speedFactor < 0.0)

--- a/xbmc/games/addons/playback/GameLoop.h
+++ b/xbmc/games/addons/playback/GameLoop.h
@@ -32,8 +32,6 @@ namespace GAME
 
     virtual void FrameEvent() = 0;
     virtual void RewindEvent() = 0;
-    virtual void HwContextReset() = 0;
-    virtual void CreateHwRenderContext() = 0;
   };
 
   class CGameLoop : protected CThread
@@ -64,6 +62,5 @@ namespace GAME
     double                   m_lastFrameMs;
     CEvent                   m_sleepEvent;
     CCriticalSection         m_mutex;
-    bool                     m_firstRun;
   };
 }


### PR DESCRIPTION
I have four fixes for your GL work
1. Cleans up RetroGlRenderPicture.h
2. Moves GL code to a new class
3. Move the messy `(data == reinterpret_cast<const uint8_t*>(-1))` comparison to game.libretro: https://github.com/kodi-game/game.libretro/commit/43583db (not merged yet)
4. Removes the GL stuff added to the playback code

Also, I rebased your `retroplayer-17alpha1-gl` patch on `retroplayer-17alpha2`. Here are the commits (cleaned up a little) with these fixes: https://github.com/garbear/xbmc/commits/retroplayer-gl
